### PR TITLE
Set suggested memory to 2Gi

### DIFF
--- a/stacks/op-scim-bridge/do_config.yml
+++ b/stacks/op-scim-bridge/do_config.yml
@@ -1,4 +1,4 @@
 minimum_resource_requirements:
   node_count: 2
   cpu: "1.0"
-  memory: "4Gi"
+  memory: "2Gi"


### PR DESCRIPTION
We can go ahead and set more modest recommendations for the required memory with us setting more aggressive resource limits in the upstream Helm chart. See https://github.com/1Password/op-scim-helm/pull/54 for details.